### PR TITLE
fix output array assembly for large structures

### DIFF
--- a/prism-js-fold.js
+++ b/prism-js-fold.js
@@ -42,17 +42,20 @@ function insertFold(inputBuffer, depth, context) {
         ...currentLineStart,
         ...currentLineEnd,
         ...firstLineContentWrapperClose,
-        ...summaryCloseFragment,
-        ...result,
+        ...summaryCloseFragment
+      );
+      result.forEach(function(v) {output.push(v)});
+      output.push(
         ...detailsCloseFragment,
         ...lastLineWrapperOpen,
         ...resultLastLine,
         ...lastLineWrapperClose,
         symbolPairMap[symbol]
-      )
+      );
       remaining = resultRemaining
     } else {
-      output.push(...result, symbolPairMap[symbol])
+      result.forEach(function(v) {output.push(v)});
+      output.push(symbolPairMap[symbol])
       remaining = resultRemaining
     }
   }


### PR DESCRIPTION
This is to fix an exception looking like this:

```javascript

Uncaught RangeError: too many arguments provided for a function call
    createFold prism-js-fold.js:38
    insertFold prism-js-fold.js:65
    createFold prism-js-fold.js:27
    insertFold prism-js-fold.js:65
    createFold prism-js-fold.js:27
    insertFold prism-js-fold.js:65
    createFold prism-js-fold.js:27
    insertFold prism-js-fold.js:65
    insertFolds prism-js-fold.js:86
```

Reason is that the maximum number of arguments to give into a function is limited by the browser and is exceeded here.
The result array may become very large. I have an example where it contains 574497 entries. At this point, it's not only slow,  but causes a crash. 